### PR TITLE
Model Loading

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -5,5 +5,9 @@ add_executable(
 	"limbo/hyperparametertuning.cpp"
 )
 
+if (LIMBO_USE_INTEL_MKL)
+	target_compile_definitions(limbo_benchmarks PRIVATE EIGEN_USE_MKL_ALL)
+endif()
+
 target_link_libraries(limbo_benchmarks PUBLIC limbo benchmark::benchmark_main limbo)
 install(TARGETS limbo_benchmarks)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,5 +8,8 @@ set(example_targets limbo_example_mono_dim limbo_example_obs_multi limbo_example
 
 foreach(targ ${example_targets})
 	target_link_libraries(${targ} PUBLIC limbo)
+	if (LIMBO_USE_INTEL_MKL)
+		target_compile_definitions(${targ} PRIVATE EIGEN_USE_MKL_ALL)
+	endif()
 endforeach()
 install(TARGETS ${example_targets})

--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -191,7 +191,7 @@ namespace limbo {
             template <typename Archive>
             void loadFromArchive(Archive const& archive )
             {
-	            _model.load(archive);
+	            _model = model_type::load(archive);
                 _total_iterations = _model.observations().size();
             }
 

--- a/src/limbo/stat/gp.hpp
+++ b/src/limbo/stat/gp.hpp
@@ -77,7 +77,7 @@ namespace limbo {
                     point[dim_in] = x;
                     if (dim_in == current.size() - 1) {
                         auto [mu, sigma_sq] = bo.model().query(point);
-                        auto [acqui, gradient] = typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(point, false);
+                        auto [acqui, gradient] = typename BO::acquisition_function_t(bo.model(), bo.total_iterations())(point, false);
                         ofs << point.transpose() << " "
                             << mu << " "
                             << sigma_sq << " "

--- a/src/limbo/stat/gp_acquisitions.hpp
+++ b/src/limbo/stat/gp_acquisitions.hpp
@@ -65,7 +65,7 @@ namespace limbo {
 
                 if (!bo.samples().empty()) {
                     auto [mu, sigma] = bo.model().query(bo.samples().back());
-                    auto [acqui, gradient] = typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.samples().back(), false);
+                    auto [acqui, gradient] = typename BO::acquisition_function_t(bo.model(), bo.total_iterations())(bo.samples().back(), false);
                     (*this->_log_file) << bo.total_iterations() << " " << afun(mu) << " " << sigma << " " << acqui << std::endl;
                 }
             }

--- a/src/limbo/stat/model_export.hpp
+++ b/src/limbo/stat/model_export.hpp
@@ -14,16 +14,16 @@ namespace limbo::stat
 		void operator()(BO const& bo)
 		{
 			assert(bo.model().dim_in() == 1);
-			std::ofstream f(dir_ / (std::to_string(bo.current_iteration()) + ".dat"));
+			std::ofstream f(dir_ / (std::to_string(bo.total_iterations()) + ".dat"));
 			using acqFuncT = typename std::decay_t<decltype(bo)>::acquisition_function_t;
-			acqFuncT acquisitionFunction(bo.model(), bo.current_iteration());
+			acqFuncT acquisitionFunction(bo.model(), bo.total_iterations());
 			for (int i = 0; i < 100; ++i) {
 				Eigen::VectorXd v = tools::make_vector(i / 99.0);
 				auto [mu, sigma_sq] = bo.model().query(v);
 				auto [acqVal, grad] = acquisitionFunction(v, false);
 				f << v.transpose() << " " << mu[0] << " " << std::sqrt(sigma_sq) << " " << acqVal << std::endl;
 			}
-			bo.model().save(serialize::TextArchive((dir_ / (std::to_string(bo.current_iteration()) + ".model")).string()));
+			bo.model().save(serialize::TextArchive((dir_ / (std::to_string(bo.total_iterations()) + ".model")).string()));
 		}
 	};
 }

--- a/src/limbo/stop/max_iterations.hpp
+++ b/src/limbo/stop/max_iterations.hpp
@@ -71,7 +71,7 @@ namespace limbo {
             {
                 if (!Stop_MaxIterations::enabled())
                     return false;
-                if(bo.current_iteration() >= Stop_MaxIterations::iterations())
+                if(bo.total_iterations() >= Stop_MaxIterations::iterations())
                 {
 					stopMessage = fmt::format("The maximimum iteration number of {} was reached", Stop_MaxIterations::iterations());
                     return true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,11 @@ add_executable(
 
 target_compile_definitions(limbo_tests PRIVATE LIMBO_TEST_TEMP_DIR="${CMAKE_CURRENT_SOURCE_DIR}/temp")
 target_link_libraries(limbo_tests PUBLIC limbo GTest::gtest_main)
+
+if (LIMBO_USE_INTEL_MKL)
+	target_compile_definitions(limbo_tests PRIVATE EIGEN_USE_MKL_ALL)
+endif()
+
 install(TARGETS limbo_tests)
 
 include(GoogleTest) 

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -14,5 +14,8 @@ endif()
 
 foreach(targ ${tutorial_targets})
 	target_link_libraries(${targ} PUBLIC limbo)
+	if (LIMBO_USE_INTEL_MKL)
+		target_compile_definitions(${targ} PRIVATE EIGEN_USE_MKL_ALL)
+	endif()
 endforeach()
 install(TARGETS ${tutorial_targets})


### PR DESCRIPTION
This PR changes BOptimizer to no longer keep duplicate observation data that mirror the model data. Public methods are added to allow initializing the optimizer from a previously saved model.

This PR fixes a CMAKE issue that prevented all tests and examples from building due to a missing `EIGEN_USE_MKL_ALL` definition.