### PR TITLE
Readability matters. Fix test race condition

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -26,14 +26,14 @@
       "description": "Target Windows with the Visual Studio development environment.",
       "inherits": "default",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
       "name": "MSVC-Debug-TBB",
       "inherits": "MSVC-Debug",
       "cacheVariables": {
-        "LIMBO_USE_TBB":  "ON"
+        "LIMBO_USE_TBB": "ON"
       }
     },
     {
@@ -49,6 +49,20 @@
       "inherits": "MSVC-Release",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "/fp:fast /EHsc"
+      }
+    },
+    {
+      "name": "MSVC_ASAN",
+      "description": "Target Windows with the Visual Studio development environment.",
+      "inherits": "default",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_TARGET_TRIPLET": "x64-windows-digilens-asan",
+        "VCPKG_HOST_TRIPLET": "x64-windows-digilens-asan"
+      },
+      "environment": {
+         "CFLAGS": "/fsanitize=address",
+         "CXXFLAGS": "/fsanitize=address"
       }
     },
     {

--- a/benchmarks/limbo/bench.cpp
+++ b/benchmarks/limbo/bench.cpp
@@ -74,7 +74,7 @@ struct Params {
         BO_PARAM(double, l, 1);
     };
     struct acqui_ucb : public defaults::acqui_ucb {
-        BO_PARAM(double, alpha, 0.125);
+        BO_PARAM(double, kappa, 0.125);
     };
     struct acqui_ei : public defaults::acqui_ei {
     };

--- a/benchmarks/limbo/hyperparametertuning.cpp
+++ b/benchmarks/limbo/hyperparametertuning.cpp
@@ -95,7 +95,7 @@ void kernelLFOpt(benchmark::State& state)
 
 		for (auto _ : state)
 		{
-			limbo::model::GP<
+			limbo::model::GaussianProcess<
 				limbo::kernel::SquaredExpARD<Params::kernel_opt, Params::kernel_squared_exp_ard>,
 				limbo::mean::Data,
 				limbo::model::gp::KernelLFOpt<limbo::opt::Rprop<Params::opt_rprop>>
@@ -110,7 +110,7 @@ void kernelLFOpt(benchmark::State& state)
 
 		for (auto _ : state)
 		{
-			limbo::model::GP<
+			limbo::model::GaussianProcess<
 				limbo::kernel::SquaredExpARD<Params::kernel_opt, Params::kernel_squared_exp_ard>,
 				limbo::mean::Data,
 				limbo::model::gp::KernelLFOpt<limbo::opt::Irpropplus<Params::opt_irpropplus>>
@@ -126,7 +126,7 @@ void kernelLFOpt(benchmark::State& state)
 
 		for (auto _ : state)
 		{
-			limbo::model::GP<
+			limbo::model::GaussianProcess<
 				limbo::kernel::SquaredExpARD<Params::kernel_opt, Params::kernel_squared_exp_ard>,
 				limbo::mean::Data,
 				limbo::model::gp::KernelLFOpt<limbo::opt::ParallelRepeater<Params::opt_parallel, limbo::opt::Irpropplus<Params::opt_irpropplus>>>
@@ -143,7 +143,7 @@ void kernelLFOpt(benchmark::State& state)
 
 		for (auto _ : state)
 		{
-			limbo::model::GP<
+			limbo::model::GaussianProcess<
 				limbo::kernel::SquaredExpARD<Params::kernel_opt, Params::kernel_squared_exp_ard>,
 				limbo::mean::Data,
 				limbo::model::gp::KernelLFOpt<limbo::opt::ParallelRepeater<Params::opt_parallel, limbo::opt::Irpropplus<Params::opt_irpropplus>>>

--- a/examples/mono_dim.cpp
+++ b/examples/mono_dim.cpp
@@ -123,7 +123,7 @@ int main()
 {
     using Kernel_t = kernel::MaternFiveHalves<Params::kernel, Params::kernel_maternfivehalves>;
     using Mean_t = mean::Data;
-    using GP_t = model::GP<Kernel_t, Mean_t>;
+    using GP_t = model::GaussianProcess<Kernel_t, Mean_t>;
     using Acqui_t = acqui::UCB<Params::acqui_ucb, GP_t>;
     using stat_t = boost::fusion::vector<limbo::stat::ConsoleSummary,
         limbo::stat::Samples,

--- a/examples/mono_dim.cpp
+++ b/examples/mono_dim.cpp
@@ -71,7 +71,7 @@ using namespace limbo;
               };
 #endif
               struct acqui_ucb {
-                  BO_PARAM(double, alpha, 0.1);
+                  BO_PARAM(double, kappa, 0.1);
               };
 
               struct kernel : public defaults::kernel {

--- a/examples/obs_multi.cpp
+++ b/examples/obs_multi.cpp
@@ -112,7 +112,7 @@ int main()
 {
     using Kernel_t = kernel::MaternFiveHalves<Params::kernel, Params::kernel_maternfivehalves>;
     using Mean_t = mean::Data;
-    using GP_t = model::GP<Kernel_t, Mean_t>;
+    using GP_t = model::GaussianProcess<Kernel_t, Mean_t>;
     using Acqui_t = acqui::GP_UCB<Params::acqui_gpucb, GP_t>;
 
     bayes_opt::BOptimizer<Params, GP_t, Acqui_t> opt(2);

--- a/examples/obs_multi_auto_mean.cpp
+++ b/examples/obs_multi_auto_mean.cpp
@@ -199,7 +199,7 @@ int main()
 
     using Kernel_t = kernel::SquaredExpARD<Params::kernel, Params::kernel_squared_exp_ard>;
     using Mean_t = mean::FunctionARD<MeanComplet<Params>>;
-    using GP_t = model::GP<Kernel_t, Mean_t, model::gp::KernelMeanLFOpt<opt::Rprop<Params::opt_rprop>>>;
+    using GP_t = model::GaussianProcess<Kernel_t, Mean_t, model::gp::KernelMeanLFOpt<opt::Rprop<Params::opt_rprop>>>;
     using Acqui_t = UCB_multi<Params, GP_t>;
 
     bayes_opt::BOptimizer<Params, GP_t, Acqui_t> opt(2);

--- a/src/limbo/acqui/gp_ucb.hpp
+++ b/src/limbo/acqui/gp_ucb.hpp
@@ -64,7 +64,7 @@ namespace limbo {
     namespace acqui {
         /** @ingroup acqui
         \rst
-        GP-UCB (Upper Confidence Bound). See :cite:`brochu2010tutorial`, p. 15. See also: http://arxiv.org/abs/0912.3995
+        GaussianProcess-UCB (Upper Confidence Bound). See :cite:`brochu2010tutorial`, p. 15. See also: http://arxiv.org/abs/0912.3995
 
         .. math::
           UCB(x) = \mu(x) + \kappa \sigma(x).

--- a/src/limbo/acqui/ucb.hpp
+++ b/src/limbo/acqui/ucb.hpp
@@ -56,7 +56,7 @@ namespace limbo {
     namespace defaults {
         struct acqui_ucb {
             /// @ingroup acqui_defaults
-            BO_PARAM(double, alpha, 0.5);
+            BO_PARAM(double, kappa, 0.5);
         };
     }
     namespace acqui {
@@ -65,10 +65,10 @@ namespace limbo {
         Classic UCB (Upper Confidence Bound). See :cite:`brochu2010tutorial`, p. 14
 
           .. math::
-            UCB(x) = \mu(x) + \alpha \sigma(x).
+            UCB(x) = \mu(x) + \kappa \sigma(x).
 
         Parameters:
-          - ``double alpha``
+          - ``double kappa``
         \endrst
         */
         template <typename AcquiUcb, concepts::Model Model>
@@ -80,7 +80,7 @@ namespace limbo {
             {
                 assert(!gradient);
                 auto [mu, sigma_sq] = _model.query(v);
-                return opt::no_grad(mu + AcquiUcb::alpha() * sqrt(sigma_sq));
+                return opt::no_grad(mu + AcquiUcb::kappa() * sqrt(sigma_sq));
             }
 
         protected:

--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -123,7 +123,7 @@ namespace limbo {
 		+================+=============+=========+===============+
 		|init. func.     |InitializerT | initfun | RandomSampling|
 		+----------------+-------------+---------+---------------+
-		|model           |model_t      | modelfun| GP<...>       |
+		|model           |model_t      | modelfun| GaussianProcess<...>       |
 		+----------------+-------------+---------+---------------+
 		|acquisition fun.|aqui_t       | acquifun| GP_UCB        |
 		+----------------+-------------+---------+---------------+
@@ -135,7 +135,7 @@ namespace limbo {
         +----------------+-------------+----------+---------------+
        \endrst
 
-       For GP, the default value is: ``model::GP<Params, kf_t, mean_t, opt_t>>``,
+       For GaussianProcess, the default value is: ``model::GaussianProcess<Params, kf_t, mean_t, opt_t>>``,
          - with ``kf_t = kernel::SquaredExpARD<Params>``
          - with ``mean_t = mean::Data<Params>``
          - with ``opt_t = model::gp::KernelLFOpt<Params>``
@@ -160,7 +160,7 @@ namespace limbo {
        */
 		template <
             class Params,
-        	concepts::Model model_type = model::GP<kernel::MaternFiveHalves<typename Params::kernel, typename Params::kernel_maternfivehalves>>,
+        	concepts::Model model_type = model::GaussianProcess<kernel::MaternFiveHalves<typename Params::kernel, typename Params::kernel_maternfivehalves>>,
 			concepts::AcquisitionFunc acqui_t = acqui::UCB<typename Params::acqui_ucb, model_type>,
 			typename init_t = init::RandomSampling<typename Params::init_randomsampling>,
     		typename StoppingCriteria = boost::fusion::vector<stop::MaxIterations<typename Params::stop_maxiterations>>,

--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -118,21 +118,21 @@ namespace limbo {
 
        This class is templated by several types with default values (thanks to boost::parameters).
 
-		+----------------+---------+---------+---------------+
-		|type            |typedef  | argument| default       |
-		+================+=========+=========+===============+
-		|init. func.     |init_t   | initfun | RandomSampling|
-		+----------------+---------+---------+---------------+
-		|model           |model_t  | modelfun| GP<...>       |
-		+----------------+---------+---------+---------------+
-		|acquisition fun.|aqui_t   | acquifun| GP_UCB        |
-		+----------------+---------+---------+---------------+
-		|statistics      | stat_t  | statfun | see below     |
-		+----------------+---------+---------+---------------+
-		|stopping crit.  | stop_t  | stopcrit| MaxIterations |
-		+----------------+---------+---------+---------------+
-		|acqui. optimizer|acquiopt_t| acquiopt | see below |
-        +----------------+------------+----------+---------------+
+		+----------------+-------------+---------+---------------+
+		|type            |typedef      | argument| default       |
+		+================+=============+=========+===============+
+		|init. func.     |InitializerT | initfun | RandomSampling|
+		+----------------+-------------+---------+---------------+
+		|model           |model_t      | modelfun| GP<...>       |
+		+----------------+-------------+---------+---------------+
+		|acquisition fun.|aqui_t       | acquifun| GP_UCB        |
+		+----------------+-------------+---------+---------------+
+		|statistics      | stat_t      | statfun | see below     |
+		+----------------+-------------+---------+---------------+
+		|stopping crit.  | stop_t      | stopcrit| MaxIterations |
+		+----------------+-------------+---------+---------------+
+		|acqui. optimizer|acquiopt_t   | acquiopt | see below |
+        +----------------+-------------+----------+---------------+
        \endrst
 
        For GP, the default value is: ``model::GP<Params, kf_t, mean_t, opt_t>>``,
@@ -178,10 +178,7 @@ namespace limbo {
             using constraint_func_t = std::function<std::pair<double, std::optional<Eigen::VectorXd>>(Eigen::VectorXd, bool)>;
 
             /// default constructor
-            BOptimizer(int dimIn):
-				acqui_optimizer(acqui_opt_t::create(dimIn)),
-				_model(dimIn)
-            {}
+            BOptimizer(int dimIn);
 
             BOptimizer(const BOptimizer& other) = delete; // copy is disabled (dangerous and useless)
             BOptimizer& operator=(const BOptimizer& other) = delete; // copy is disabled (dangerous and useless)
@@ -189,206 +186,47 @@ namespace limbo {
             BOptimizer& operator=(BOptimizer&& other) = default;
 
             template <typename Archive>
-            void loadFromArchive(Archive const& archive )
-            {
-	            _model = model_type::load(archive);
-                _total_iterations = _model.observations().size();
-            }
+            void loadFromArchive(Archive const& archive );
 
             /// The main function (run the Bayesian optimization algorithm)
             template <concepts::StateFunc StateFunction>
-            std::string optimize(const StateFunction& sfun, bool reset = true, std::optional<Eigen::VectorXd> const& initialPoint = std::nullopt)
-            {
-                if (reset) {
-                    _total_iterations = 0;
-                    _model = model_type(sfun.dim_in());
-                }
-
-                if (_total_iterations == 0) {
-                    EvaluationStatus initStatus;
-                    if (initialPoint.has_value())
-                    {
-	                    initStatus = eval_and_add(sfun, initialPoint.value());
-                        if (initStatus == TERMINATE)
-	                    {
-	                        return "Initialization requested that optimization be terminated";
-	                    }
-                    }
-                    initStatus = init_t()(sfun, *this);
-                    if (initStatus == TERMINATE)
-                    {
-                        return "Initialization requested that optimization be terminated";
-                    }
-                }
-
-                if (Params::bayes_opt_boptimizer::hp_period() > 0)
-                { // If hyperparameter tuning is enabled then run it after initialization
-					#ifdef SAVE_HP_MODELS
-                    _model.save(serialize::TextArchive((outputDir_ / "modelArchive_init").string()));
-					#endif
-                	_model.optimize_hyperparams();
-					#ifdef SAVE_HP_MODELS
-					_model.save(serialize::TextArchive((outputDir_ / "modelArchive_post_init").string()));
-					#endif
-                }
-
-                std::optional<std::vector<std::pair<double, double>>> parameterBounds = std::nullopt;
-                if (Params::bayes_opt_boptimizer::bounded())
-                {
-                    parameterBounds = std::vector<std::pair<double, double>>(_model.dim_in(), std::make_pair( 0.0, 1.0 ));
-                }
-
-                std::string stopMessage = "";
-                // While no stopping criteria return `true`
-                while (!boost::fusion::accumulate(stopping_criteria_, false, [this, msgPtr=&stopMessage](bool state, concepts::StoppingCriteria auto const& stop_criteria) { return state || stop_criteria(*this, *msgPtr); }))
-                {
-                    acquisition_function_t acqui(_model, this->_total_iterations);
-
-                    Eigen::VectorXd starting_point = tools::random_vector(sfun.dim_in(), Params::bayes_opt_boptimizer::bounded());
-                    Eigen::VectorXd new_sample = acqui_optimizer.optimize(
-                        [&](const Eigen::VectorXd& x, bool g) -> opt::eval_t { return acqui(x, g); },
-                        starting_point, 
-                        parameterBounds);
-
-                	auto status = this->eval_and_add(sfun, new_sample);
-                    if (status == TERMINATE)
-                    {
-                        stopMessage = "Objective function requested that optimization be terminated";
-                        break;
-                    }
-
-                    if (Params::bayes_opt_boptimizer::stats_enabled()) {
-                        //update stats
-                        boost::fusion::for_each(
-                            stat_, 
-                            [this](concepts::StatsFunc auto& func)
-                            {
-	                            func.template operator()<decltype(*this)>(*this);
-                            });
-                    }
-
-                    if (Params::bayes_opt_boptimizer::hp_period() > 0)
-                    {
-                        if ((iterations_since_hp_optimize_ + 1) % static_cast<int>(Params::bayes_opt_boptimizer::hp_period() + _total_iterations * Params::bayes_opt_boptimizer::hp_period_scaler()) == 0)
-                        {
-                            iterations_since_hp_optimize_ = 0;
-                            _model.optimize_hyperparams();
-#ifdef SAVE_HP_MODELS
-                            _model.save(serialize::TextArchive((outputDir_ / ("modelArchive_" + std::to_string(_total_iterations))).string()));
-#endif
-                        }
-                        else
-                        {
-                            ++iterations_since_hp_optimize_;
-                        }
-                    }
-
-                    ++_total_iterations;
-                }
-                return stopMessage;
-            }
+            std::string optimize(const StateFunction& sfun, bool reset = true, std::optional<Eigen::VectorXd> const& initialPoint = std::nullopt);
 
             /// return the best observation so far (i.e. max(f(x)))
-            double best_observation() const
-            {
-                auto max_e = std::max_element(observations().begin(), observations().end());
-                return observations()[std::distance(observations().begin(), max_e)];
-            }
+            double best_observation() const;
 
             /// return the best sample so far (i.e. the argmax(f(x)))
-            const Eigen::VectorXd& best_sample() const
-            {
-                auto max_e = std::max_element(observations().begin(), observations().end());
-                return samples()[std::distance(observations().begin(), max_e)];
-            }
+            const Eigen::VectorXd& best_sample() const;
 
-            model_type const& model() const { return _model; }
+            model_type const& model() const;
 
             /// return the vector of points of observations (observations can be multi-dimensional, hence the VectorXd) -- f(x)
-            std::vector<double> const& observations() const { return _model.observations(); }
+            std::vector<double> const& observations() const;
 
             /// return the list of the points that have been evaluated so far (x)
-            std::vector<Eigen::VectorXd> const& samples() const { return _model.samples(); }
+            std::vector<Eigen::VectorXd> const& samples() const;
 
             /// return the current iteration number
-            int total_iterations() const { return _total_iterations; }
+            int total_iterations() const;
 
-            acqui_opt_t const& acquisitionOptimizer() const { return acqui_optimizer; }
+            template<concepts::EvalFunc EvalFunc>
+            Eigen::VectorXd optimizeFunction(const EvalFunc& evalFunc, Eigen::VectorXd const& initPoint, std::optional<std::vector<std::pair<double, double>>> const& bounds) const;
 
             /// Evaluate a sample and add the result to the 'database' (sample / observations vectors)
             template <concepts::StateFunc StateFunction>
-            EvaluationStatus eval_and_add(const StateFunction& seval, const Eigen::VectorXd& sample)
-            {
-                auto [status, observation] = seval(sample);
-                if (status == OK) // TODO if `seval` returns `SKIP` we need to do something to avoid that sample being tested again. I.E addd a very negative observation
-                {
-                    /// Add a new sample / observation pair
-					/// - does not update the model!
-					/// - we don't add NaN and inf observations
-					if (std::isnan(observation))
-					{
-                        throw EvaluationError("Merit function returned a NaN value");
-					}
-                    if (std::isinf(observation)) 
-                    {
-                        throw EvaluationError("Merit function returned an infinite value");
-                    }
-                    _model.add_sample(sample, observation);
-                }
-                return status;
-            }
+            EvaluationStatus eval_and_add(const StateFunction& seval, const Eigen::VectorXd& sample);
 
-            bool isBounded() const { return Params::bayes_opt_boptimizer::bounded(); }
+            bool isBounded() const;
 
-            template<concepts::EvalFunc Func>
-            void addInequalityConstraint(Func func)
-            {
-                auto& it = inequalityConstraints_.emplace_back(std::make_unique<constraint_func_t>(std::move(func)));
-                acqui_optimizer.add_inequality_constraint(it.get());
-            }
+            void addInequalityConstraint(constraint_func_t func);
 
-            template<concepts::EvalFunc Func>
-            void addEqualityConstraint(Func func)
-            {
-                auto& it = equalityConstraints_.emplace_back(std::make_unique<constraint_func_t>(std::move(func)));
-                acqui_optimizer.add_equality_constraint(it.get());
-            }
+            void addEqualityConstraint(constraint_func_t func);
 
-            bool hasConstraints() const
-            {
-                return !equalityConstraints_.empty() || !inequalityConstraints_.empty();
-            }
+            bool hasConstraints() const;
 
-            bool constraintsAreSatisfied(Eigen::VectorXd const& sampleLocation) const
-            {
-	            for (auto const& ineq : inequalityConstraints_)
-	            {
-                    auto [val, gradient] = ineq->operator()(sampleLocation, false);
-                    if (val >= 0)
-                    {
-                        return false;
-                    }
-	            }
-                for (auto const& eq : equalityConstraints_)
-                {
-                    auto [val, gradient] = eq->operator()(sampleLocation, false);
-                    if (std::abs(val) > 1e-8) // Ideally the value should be 0 but we use 1e-8 to give a little wiggle room.
-                    {
-                        return false;
-                    }
-                }
-                return true;
-            }
+            void setStatsOutputDirectory(std::filesystem::path const& dir);
 
-            void setStatsOutputDirectory(std::filesystem::path const& dir)
-            {
-                assert(exists(dir));
-                assert(std::filesystem::is_directory(dir));
-                outputDir_ = dir;
-                boost::fusion::for_each(stat_, [&dir](auto& stat) {stat.setOutputDirectory(dir); });
-            }
-
-		protected:
+        protected:
             typename boost::mpl::if_<boost::fusion::traits::is_sequence<StoppingCriteria>, StoppingCriteria, boost::fusion::vector<StoppingCriteria>>::type stopping_criteria_;
             stats_t  stat_;
             std::filesystem::path outputDir_;
@@ -396,27 +234,32 @@ namespace limbo {
             size_t _total_iterations = 0;
             size_t iterations_since_hp_optimize_ = 0;
             acqui_opt_t acqui_optimizer;
-            std::vector<std::unique_ptr<constraint_func_t>> equalityConstraints_;
-            std::vector<std::unique_ptr<constraint_func_t>> inequalityConstraints_;
+            std::vector<constraint_func_t> equalityConstraints_;
+            std::vector<constraint_func_t> inequalityConstraints_;
             model_type _model;
         };
 
-        namespace _default_hp {
-            template <typename Params>
-            using model_t = model::GPOpt<Params>;
-            template <typename Params>
-            using acqui_t = acqui::UCB<typename Params::acqui_ucb, model_t<Params>>;
-        }
 
         /// A shortcut for a BOptimizer with UCB + GPOpt
         /// The acquisition function and the model CANNOT be tuned (use BOptimizer for this)
         template <class Params,
-			typename init_t = init::RandomSampling<typename Params::init_randomsampling>,
-    		typename StoppingCriteria = boost::fusion::vector<stop::MaxIterations<typename Params::stop_maxiterations>>,
-    		typename Stat =  boost::fusion::vector<stat::Samples, stat::AggregatedObservations, stat::ConsoleSummary>,
+			typename InitializerT = init::RandomSampling<typename Params::init_randomsampling>,
+    		typename StoppingCriteriaT = boost::fusion::vector<stop::MaxIterations<typename Params::stop_maxiterations>>,
+    		typename StatT =  boost::fusion::vector<stat::Samples, stat::AggregatedObservations, stat::ConsoleSummary>,
 			typename acqui_opt_t = typename defaults<Params>::acquiopt_t>
-        using BOptimizerHPOpt = BOptimizer<Params, _default_hp::model_t<Params>, _default_hp::acqui_t<Params>, init_t, StoppingCriteria, Stat, acqui_opt_t>;
+        using BOptimizerHPOpt = BOptimizer<
+            Params,
+            model::GPOpt<Params>,
+            acqui::UCB<typename Params::acqui_ucb, model::GPOpt<Params>>,
+    		InitializerT,
+    		StoppingCriteriaT,
+    		StatT,
+    		acqui_opt_t>;
 
     }
 }
+
+// Include the implementation of boptimizers methods
+#include "boptimizer_impl.hpp"
+
 #endif

--- a/src/limbo/bayes_opt/boptimizer_impl.hpp
+++ b/src/limbo/bayes_opt/boptimizer_impl.hpp
@@ -1,0 +1,203 @@
+#pragma once
+
+namespace limbo::bayes_opt
+{
+
+//Shorten the definition of the template class
+#define OptClass(returnType)  template <class Params, concepts::Model model_type, concepts::AcquisitionFunc acqui_t, typename init_t, typename \
+			StoppingCriteria, typename Stat, concepts::Optimizer acqui_opt_t> \
+	returnType BOptimizer<Params, model_type, acqui_t, init_t, StoppingCriteria, Stat, acqui_opt_t>
+
+//Shorten the definition of a template function of the template class
+#define OptClassTemplateFunction(templateStatement, returnType)  template <class Params, concepts::Model model_type, concepts::AcquisitionFunc acqui_t, typename init_t, typename \
+			StoppingCriteria, typename Stat, concepts::Optimizer acqui_opt_t> \
+			templateStatement \
+			returnType BOptimizer<Params, model_type, acqui_t, init_t, StoppingCriteria, Stat, acqui_opt_t>
+
+
+	template <class Params, concepts::Model model_type, concepts::AcquisitionFunc acqui_t, typename init_t,
+		typename StoppingCriteria, typename Stat, concepts::Optimizer acqui_opt_t> 
+	BOptimizer<Params, model_type, acqui_t, init_t, StoppingCriteria, Stat, acqui_opt_t>::BOptimizer(int dimIn) :
+		acqui_optimizer(acqui_opt_t::create(dimIn)),
+		_model(dimIn)
+	{}
+
+	OptClassTemplateFunction(template <typename Archive>, void)::loadFromArchive(
+		Archive const& archive)
+	{
+		_model = model_type::load(archive);
+		_total_iterations = _model.observations().size();
+	}
+
+	OptClassTemplateFunction(template <concepts::StateFunc StateFunction>, std::string)::optimize(
+		StateFunction const& sfun, bool reset, std::optional<Eigen::VectorXd> const& initialPoint)
+	{
+		if (reset) {
+			_total_iterations = 0;
+			_model = model_type(sfun.dim_in());
+		}
+
+		if (_total_iterations == 0) {
+			EvaluationStatus initStatus;
+			if (initialPoint.has_value())
+			{
+				initStatus = eval_and_add(sfun, initialPoint.value());
+				if (initStatus == TERMINATE)
+				{
+					return "Initialization requested that optimization be terminated";
+				}
+			}
+			initStatus = init_t()(sfun, *this);
+			if (initStatus == TERMINATE)
+			{
+				return "Initialization requested that optimization be terminated";
+			}
+		}
+
+		if (Params::bayes_opt_boptimizer::hp_period() > 0)
+		{ // If hyperparameter tuning is enabled then run it after initialization
+#ifdef SAVE_HP_MODELS
+                _model.save(serialize::TextArchive((outputDir_ / "modelArchive_init").string()));
+#endif
+			_model.optimize_hyperparams();
+#ifdef SAVE_HP_MODELS
+				_model.save(serialize::TextArchive((outputDir_ / "modelArchive_post_init").string()));
+#endif
+		}
+
+		std::optional<std::vector<std::pair<double, double>>> parameterBounds = std::nullopt;
+		if (Params::bayes_opt_boptimizer::bounded())
+		{
+			parameterBounds = std::vector<std::pair<double, double>>(_model.dim_in(), std::make_pair( 0.0, 1.0 ));
+		}
+
+		std::string stopMessage = "";
+		// While no stopping criteria return `true`
+		while (!boost::fusion::accumulate(stopping_criteria_, false, [this, msgPtr=&stopMessage](bool state, concepts::StoppingCriteria auto const& stop_criteria) { return state || stop_criteria(*this, *msgPtr); }))
+		{
+			acquisition_function_t acqui(_model, this->_total_iterations);
+
+			Eigen::VectorXd starting_point = tools::random_vector(sfun.dim_in(), Params::bayes_opt_boptimizer::bounded());
+			Eigen::VectorXd new_sample = acqui_optimizer.optimize(
+				[&](const Eigen::VectorXd& x, bool g) -> opt::eval_t { return acqui(x, g); },
+				starting_point, 
+				parameterBounds);
+
+			auto status = this->eval_and_add(sfun, new_sample);
+			if (status == TERMINATE)
+			{
+				stopMessage = "Objective function requested that optimization be terminated";
+				break;
+			}
+
+			if (Params::bayes_opt_boptimizer::stats_enabled()) {
+				//update stats
+				boost::fusion::for_each(
+					stat_, 
+					[this](concepts::StatsFunc auto& func)
+					{
+						func.template operator()<decltype(*this)>(*this);
+					});
+			}
+
+			if (Params::bayes_opt_boptimizer::hp_period() > 0)
+			{
+				if ((iterations_since_hp_optimize_ + 1) % static_cast<int>(Params::bayes_opt_boptimizer::hp_period() + _total_iterations * Params::bayes_opt_boptimizer::hp_period_scaler()) == 0)
+				{
+					iterations_since_hp_optimize_ = 0;
+					_model.optimize_hyperparams();
+#ifdef SAVE_HP_MODELS
+                        _model.save(serialize::TextArchive((outputDir_ / ("modelArchive_" + std::to_string(_total_iterations))).string()));
+#endif
+				}
+				else
+				{
+					++iterations_since_hp_optimize_;
+				}
+			}
+
+			++_total_iterations;
+		}
+		return stopMessage;
+	}
+
+	OptClass(double)::best_observation() const
+	{
+		auto max_e = std::max_element(observations().begin(), observations().end());
+		return observations()[std::distance(observations().begin(), max_e)];
+	}
+
+	OptClass(Eigen::VectorXd const&)::best_sample() const
+	{
+		auto max_e = std::max_element(observations().begin(), observations().end());
+		return samples()[std::distance(observations().begin(), max_e)];
+	}
+
+	OptClass(model_type const&)::model() const
+	{ return _model; }
+
+	OptClass(std::vector<double> const&)::observations() const
+	{ return _model.observations(); }
+
+	OptClass(std::vector<Eigen::VectorXd> const&)::samples() const
+	{ return _model.samples(); }
+
+	OptClass(int)::total_iterations() const
+	{ return _total_iterations; }
+
+	OptClassTemplateFunction(template <concepts::EvalFunc EvalFunc>, Eigen::VectorXd)::optimizeFunction(
+		const EvalFunc& evalFunc, const Eigen::VectorXd& initPoint,
+		std::optional<std::vector<std::pair<double, double>>> const& bounds) const
+	{
+		return acqui_optimizer.optimize(evalFunc, initPoint, bounds);
+	}
+
+	OptClassTemplateFunction(template <concepts::StateFunc StateFunction>, EvaluationStatus)::eval_and_add(const StateFunction& seval, const Eigen::VectorXd& sample)
+	{
+		auto [status, observation] = seval(sample);
+		if (status == OK) // TODO if `seval` returns `SKIP` we need to do something to avoid that sample being tested again. I.E addd a very negative observation
+		{
+			/// Add a new sample / observation pair
+				/// - does not update the model!
+				/// - we don't add NaN and inf observations
+			if (std::isnan(observation))
+			{
+				throw EvaluationError("Merit function returned a NaN value");
+			}
+			if (std::isinf(observation)) 
+			{
+				throw EvaluationError("Merit function returned an infinite value");
+			}
+			_model.add_sample(sample, observation);
+		}
+		return status;
+	}
+
+	OptClass(bool)::isBounded() const
+	{ return Params::bayes_opt_boptimizer::bounded(); }
+
+	OptClass(void)::addInequalityConstraint(constraint_func_t func)
+	{
+		auto& it = inequalityConstraints_.emplace_back(std::move(func));
+		acqui_optimizer.add_inequality_constraint(&it);
+	}
+
+	OptClass(void)::addEqualityConstraint(constraint_func_t func)
+	{
+		auto& it = equalityConstraints_.emplace_back(std::move(func));
+		acqui_optimizer.add_equality_constraint(&it);
+	}
+
+	OptClass(bool)::hasConstraints() const
+	{
+		return !equalityConstraints_.empty() || !inequalityConstraints_.empty();
+	}
+
+	OptClass(void)::setStatsOutputDirectory(std::filesystem::path const& dir)
+	{
+		assert(exists(dir));
+		assert(std::filesystem::is_directory(dir));
+		outputDir_ = dir;
+		boost::fusion::for_each(stat_, [&dir](auto& stat) {stat.setOutputDirectory(dir); });
+	}
+}

--- a/src/limbo/concepts.hpp
+++ b/src/limbo/concepts.hpp
@@ -4,9 +4,10 @@
 #include <Eigen/Dense>
 
 
-
+//These concepts are used for constraining the types passed as template parameters to the template classes
 namespace limbo::concepts
 {
+	// Helper template for a functor with return type and argument types
 	template <typename F, typename Ret, class... Args >
 	concept Callable = std::invocable<F, Args...> && std::same_as<Ret, std::invoke_result_t<F, Args...>>;
 
@@ -59,7 +60,6 @@ namespace limbo::concepts
 		{a.isBounded()} -> std::convertible_to<bool>;
 		{a.addInequalityConstraint(EvalFuncArchetype{})} -> std::convertible_to<void>;
 		{a.addEqualityConstraint(EvalFuncArchetype{})} -> std::convertible_to<void>;
-		{a.constraintsAreSatisfied(Eigen::VectorXd{})} -> std::convertible_to<bool>;
 		{a.hasConstraints()} -> std::convertible_to<bool>;
 	};
 

--- a/src/limbo/init/random_sampling.hpp
+++ b/src/limbo/init/random_sampling.hpp
@@ -88,10 +88,13 @@ namespace limbo {
                         };
                         // static_assert(concepts::EvalFunc<ConstFunc>);
 
-                        auto parameterBounds = std::vector<std::pair<double, double>>(seval.dim_in(), std::make_pair( 0.0, 1.0 ));
+                        std::optional<std::vector<std::pair<double, double>>> parameterBounds = std::nullopt;
+                        if (opt.isBounded()) {
+                            parameterBounds = std::vector<std::pair<double, double>>(seval.dim_in(), std::make_pair(0.0, 1.0));
+                        }
 
                         //find the closest coordinate to proposed_new_sample that satisfies the constraints
-	                    new_sample = opt.acquisitionOptimizer().optimize(
+	                    new_sample = opt.optimizeFunction(
                             ConstFunc, 
                             proposed_new_sample, 
                             parameterBounds);

--- a/src/limbo/model/multi_gp.hpp
+++ b/src/limbo/model/multi_gp.hpp
@@ -53,7 +53,7 @@ namespace limbo {
         /// @ingroup model
         /// A wrapper for N-output Gaussian processes.
         /// It is parametrized by:
-        /// - GP class
+        /// - GaussianProcess class
         /// - a kernel function (the same type for all GPs, but can have different parameters)
         /// - a mean function (the same type and parameters for all GPs)
         /// - [optional] an optimizer for the hyper-parameters
@@ -73,7 +73,7 @@ namespace limbo {
                 }
             }
 
-            /// Compute the GP from samples and observations. This call needs to be explicit!
+            /// Compute the GaussianProcess from samples and observations. This call needs to be explicit!
             void initialize(const std::vector<Eigen::VectorXd>& samples,
                 const std::vector<Eigen::VectorXd>& observations, bool compute_kernel = true)
             {
@@ -84,7 +84,7 @@ namespace limbo {
                 assert(_dim_out == observations[0].size());
 
                 // save observations
-                // TO-DO: Check how can we improve for not saving observations twice (one here and one for each GP)!?
+                // TO-DO: Check how can we improve for not saving observations twice (one here and one for each GaussianProcess)!?
                 _observations = observations;
 
                 // compute the new observations for the GPs
@@ -133,7 +133,7 @@ namespace limbo {
 
             /**
              \\rst
-             return :math:`\mu`, :math:`\sigma^2` (un-normalized; this will return a vector --- one for each GP). Using this method instead of separate calls to mu() and sigma() is more efficient because some computations are shared between mu() and sigma().
+             return :math:`\mu`, :math:`\sigma^2` (un-normalized; this will return a vector --- one for each GaussianProcess). Using this method instead of separate calls to mu() and sigma() is more efficient because some computations are shared between mu() and sigma().
              \\endrst
             */
             std::tuple<Eigen::VectorXd, Eigen::VectorXd> query(const Eigen::VectorXd& v) const
@@ -173,7 +173,7 @@ namespace limbo {
 
             /**
              \\rst
-             return :math:`\sigma^2` (un-normalized). This returns a vector; one value for each GP.
+             return :math:`\sigma^2` (un-normalized). This returns a vector; one value for each GaussianProcess.
              \\endrst
             */
             Eigen::VectorXd sigma(const Eigen::VectorXd& v) const
@@ -199,7 +199,7 @@ namespace limbo {
                 return _dim_out;
             }
 
-            /// return the number of samples used to compute the GP
+            /// return the number of samples used to compute the GaussianProcess
             int nb_samples() const
             {
                 return _observations.size();
@@ -256,7 +256,7 @@ namespace limbo {
             }
 
 
-            /// save the parameters and the data for the GP to the archive (text or binary)
+            /// save the parameters and the data for the GaussianProcess to the archive (text or binary)
             template <typename A>
             void save(const A& archive) const
             {
@@ -275,7 +275,7 @@ namespace limbo {
                 }
             }
 
-            /// load the parameters and the data for the GP from the archive (text or binary)
+            /// load the parameters and the data for the GaussianProcess from the archive (text or binary)
             /// if recompute is true, we do not read the kernel matrix
             /// but we recompute it given the data and the hyperparameters
             template <typename A>

--- a/src/limbo/model/sparsified_gp.hpp
+++ b/src/limbo/model/sparsified_gp.hpp
@@ -69,33 +69,33 @@ namespace limbo {
         /// A sparsification based on the density of points is performed
         /// until a desired number of points is reached
         template <typename ModelSparseGP, typename KernelFunction, typename MeanFunction = mean::Data, typename HyperParamsOptimizer = gp::NoLFOpt>
-        class SparsifiedGP : public GP<KernelFunction, MeanFunction, HyperParamsOptimizer> {
+        class SparsifiedGP : public GaussianProcess<KernelFunction, MeanFunction, HyperParamsOptimizer> {
         public:
-            using base_gp_t = GP<KernelFunction, MeanFunction, HyperParamsOptimizer>;
+            using base_gp_t = GaussianProcess<KernelFunction, MeanFunction, HyperParamsOptimizer>;
 
             /// useful because the model might be created before having samples
             SparsifiedGP(int dim_in, int dim_out)
                 : base_gp_t(dim_in, dim_out) {}
 
-            /// Compute the GP from samples and observations. This call needs to be explicit!
+            /// Compute the GaussianProcess from samples and observations. This call needs to be explicit!
             void initialize(const std::vector<Eigen::VectorXd>& samples,
                 const std::vector<Eigen::VectorXd>& observations, bool compute_kernel = true)
             {
                 /// if the number of samples is less or equal than the desired
-                /// compute the normal GP
+                /// compute the normal GaussianProcess
                 if (samples.size() <= ModelSparseGP::max_points())
                     base_gp_t::initialize(samples, observations, compute_kernel);
                 /// otherwise, sparsify the samples
                 else {
                     auto [samp, obs] = _sparsify(samples, observations);
 
-                    /// now compute the normal GP with less points
+                    /// now compute the normal GaussianProcess with less points
                     base_gp_t::initialize(samp, obs, compute_kernel);
                 }
             }
 
-            /// add sample and update the GP. If the number of samples is bigger than
-            /// the desired maximum points, we re-sparsify and re-compute the GP
+            /// add sample and update the GaussianProcess. If the number of samples is bigger than
+            /// the desired maximum points, we re-sparsify and re-compute the GaussianProcess
             void add_sample(const Eigen::VectorXd& sample, const Eigen::VectorXd& observation)
             {
                 base_gp_t::add_sample(sample, observation);

--- a/src/limbo/stop/max_predicted_value.hpp
+++ b/src/limbo/stop/max_predicted_value.hpp
@@ -79,9 +79,13 @@ namespace limbo {
                 if (bo.observations().size() == 0 || !stop_maxpredictedvalue::enabled())
                     return false;
 
+                std::optional<std::vector<std::pair<double, double>>> parameterBounds = std::nullopt;
+                if (bo.isBounded()) {
+                    parameterBounds = std::vector<std::pair<double, double>>(bo.dim_in(), std::make_pair(0.0, 1.0));
+                }
                 Eigen::VectorXd starting_point = tools::random_vector(bo.model().dim_in());
                 auto model_optimization = [&](const Eigen::VectorXd& x, bool g) { return opt::no_grad(afun(bo.model().mu(x))); };
-                auto x = bo.acquisitionOptimizer().optimize(model_optimization, starting_point, true);
+                auto x = bo.optimizeFunction(model_optimization, starting_point, parameterBounds);
                 double val = afun(bo.model().mu(x));
 
                 if (afun(bo.best_observation()) <= stop_maxpredictedvalue::ratio() * val)

--- a/src/limbo/tools/parallel.hpp
+++ b/src/limbo/tools/parallel.hpp
@@ -79,7 +79,7 @@ namespace limbo {
             /// @ingroup par_tools
             /// convert a std::vector to something else (e.g. a std::list)
             template <typename V>
-            inline std::vector<typename V::value_type> convert_vector(const V& v)
+            std::vector<typename V::value_type> convert_vector(const V& v)
             {
                 std::vector<typename V::value_type> v2(v.size());
                 std::copy(v.begin(), v.end(), v2.begin());
@@ -98,7 +98,7 @@ namespace limbo {
 #endif
 
             template <typename V>
-            inline V convert_vector(const V& v)
+            V convert_vector(const V& v)
             {
                 return v;
             }
@@ -107,7 +107,7 @@ namespace limbo {
             ///@ingroup par_tools
             /// parallel for
             template <typename F>
-            inline void loop(size_t begin, size_t end, const F& f)
+            void loop(size_t begin, size_t end, const F& f)
             {
 #ifdef LIMBO_USE_TBB
                 tbb::parallel_for(size_t(begin), end, size_t(1), [&](size_t i) {
@@ -124,7 +124,7 @@ namespace limbo {
             /// @ingroup par_tools
             /// parallel for_each
             template <typename Iterator, typename F>
-            inline void for_each(Iterator begin, Iterator end, const F& f)
+            void for_each(Iterator begin, Iterator end, const F& f)
             {
 #ifdef LIMBO_USE_TBB
                 tbb::parallel_for_each(begin, end, f);
@@ -137,7 +137,7 @@ namespace limbo {
             /// @ingroup par_tools
             /// parallel max
             template <typename T, typename F, typename C>
-            inline T max(const T& init, int num_steps, const F& f, const C& comp)
+            T max(const T& init, int num_steps, const F& f, const C& comp)
             {
 #ifdef LIMBO_USE_TBB
                 auto body = [&](const tbb::blocked_range<size_t>& r, T current_max) -> T {
@@ -170,7 +170,7 @@ namespace limbo {
             /// @ingroup par_tools
             /// parallel sort
             template <typename T1, typename T2, typename T3>
-            inline void sort(T1 i1, T2 i2, T3 comp)
+            void sort(T1 i1, T2 i2, T3 comp)
             {
 #ifdef LIMBO_USE_TBB
                 tbb::parallel_sort(i1, i2, comp);
@@ -182,7 +182,7 @@ namespace limbo {
             /// @ingroup par_tools
             /// replicate a function nb times
             template <typename F>
-            inline void replicate(size_t nb, const F& f)
+            void replicate(size_t nb, const F& f)
             {
 #ifdef LIMBO_USE_TBB
                 tbb::parallel_for(size_t(0), nb, size_t(1), [&](size_t i) {

--- a/tests/test_boptimizer.cpp
+++ b/tests/test_boptimizer.cpp
@@ -149,7 +149,7 @@ TEST(Limbo_Boptimizer, bo_inheritance)
     using Mean_t = mean::Data;
     using Stat_t = boost::fusion::vector<limbo::stat::Samples, limbo::stat::Observations>;
     using Init_t = init::NoInit;
-    using GP_t = model::GP<Kernel_t, Mean_t>;
+    using GP_t = model::GaussianProcess<Kernel_t, Mean_t>;
     using Acqui_t = acqui::UCB<Params::acqui_ucb, GP_t>;
 
     bayes_opt::BOptimizer<Params, GP_t, Acqui_t, Init_t, Stop_t, Stat_t, AcquiOpt_t> opt(eval2<Params>::dim_in());
@@ -181,7 +181,7 @@ TEST(Limbo_Boptimizer, bo_unbounded)
     using Mean_t = mean::NullFunction<Params>;
     using Stat_t = boost::fusion::vector<stat::ConsoleSummary<Params>>;
     using Init_t = init::RandomSampling<Params>;
-    using GP_t = model::GP<Params, Kernel_t, Mean_t>;
+    using GP_t = model::GaussianProcess<Params, Kernel_t, Mean_t>;
     using Acqui_t = acqui::UCB<Params, GP_t>;
 
     bayes_opt::BOptimizer<Parameters, modelfun<GP_t>, initfun<Init_t>, acquifun<Acqui_t>, acquiopt<AcquiOpt_t>, statsfun<Stat_t>, stopcrit<Stop_t>> opt;
@@ -207,7 +207,7 @@ TEST(Limbo_Boptimizer, bo_gp)
     using Mean_t = mean::Data;
     using Stat_t = boost::fusion::vector<limbo::stat::Samples, limbo::stat::Observations>;
     using Init_t = init::RandomSampling<Params::init_randomsampling>;
-    using GP_t = model::GP<Kernel_t, Mean_t>;
+    using GP_t = model::GaussianProcess<Kernel_t, Mean_t>;
     using Acqui_t = acqui::EI<Params::acqui_ei, GP_t>;
 
     bayes_opt::BOptimizer<Params, GP_t, Acqui_t, Init_t, Stop_t, Stat_t, AcquiOpt_t> opt(eval2<Params>::dim_in());
@@ -234,7 +234,7 @@ TEST(Limbo_Boptimizer, bo_gp_auto)
     using Mean_t = mean::Data;
     using Stat_t = boost::fusion::vector<limbo::stat::Samples, limbo::stat::Observations>;
     using Init_t = init::RandomSampling<Params::init_randomsampling>;
-    using GP_t = model::GP<Kernel_t, Mean_t, model::gp::KernelLFOpt<opt::Rprop<Params::opt_rprop>>>;
+    using GP_t = model::GaussianProcess<Kernel_t, Mean_t, model::gp::KernelLFOpt<opt::Rprop<Params::opt_rprop>>>;
     using Acqui_t = acqui::UCB<Params::acqui_ucb, GP_t>;
 
     bayes_opt::BOptimizer<Params, GP_t, Acqui_t, Init_t, Stop_t, Stat_t, AcquiOpt_t> opt(eval2<Params>::dim_in());
@@ -261,7 +261,7 @@ TEST(Limbo_Boptimizer, bo_gp_mean)
     using Mean_t = mean::FunctionARD<mean::Data>;
     using Stat_t = boost::fusion::vector<limbo::stat::Samples, limbo::stat::Observations>;
     using Init_t = init::RandomSampling<Params::init_randomsampling>;
-    using GP_t = model::GP<Kernel_t, Mean_t, model::gp::MeanLFOpt<opt::Rprop<Params::opt_rprop>>>;
+    using GP_t = model::GaussianProcess<Kernel_t, Mean_t, model::gp::MeanLFOpt<opt::Rprop<Params::opt_rprop>>>;
     using Acqui_t = acqui::UCB<Params::acqui_ucb, GP_t>;
 
     bayes_opt::BOptimizer<Params, GP_t, Acqui_t, Init_t, Stop_t, Stat_t, AcquiOpt_t> opt(eval2<Params>::dim_in());

--- a/tests/test_boptimizer.cpp
+++ b/tests/test_boptimizer.cpp
@@ -85,7 +85,7 @@ namespace {
         };
 
         struct acqui_ucb {
-            BO_PARAM(double, alpha, 1.0);
+            BO_PARAM(double, kappa, 1.0);
         };
 
         struct acqui_ei {

--- a/tests/test_init_functions.cpp
+++ b/tests/test_init_functions.cpp
@@ -102,7 +102,7 @@ namespace {
 TEST(Limbo_Init_Functions, no_init)
 {
     std::cout << "NoInit" << std::endl;
-    using Model_t =  model::GP<kernel::MaternFiveHalves<limbo::defaults::kernel, limbo::defaults::kernel_maternfivehalves>>;
+    using Model_t =  model::GaussianProcess<kernel::MaternFiveHalves<limbo::defaults::kernel, limbo::defaults::kernel_maternfivehalves>>;
     using Acqui_t = acqui::UCB<Params::acqui_ucb, Model_t>;
     using Init_t = init::NoInit;
     using Opt_t = bayes_opt::BOptimizer<Params, Model_t, Acqui_t, Init_t>;
@@ -123,7 +123,7 @@ TEST(Limbo_Init_Functions, random_lhs)
 {
     std::cout << "LHS" << std::endl;
 
-    using Model_t =  model::GP<kernel::MaternFiveHalves<limbo::defaults::kernel, limbo::defaults::kernel_maternfivehalves>>;
+    using Model_t =  model::GaussianProcess<kernel::MaternFiveHalves<limbo::defaults::kernel, limbo::defaults::kernel_maternfivehalves>>;
     using Acqui_t = acqui::UCB<RandLHSParams::acqui_ucb, Model_t>;
     using Init_t = init::LHS<RandLHSParams::init_lhs>;
     using Opt_t = bayes_opt::BOptimizer<RandLHSParams, Model_t, Acqui_t, Init_t>;
@@ -154,7 +154,7 @@ TEST(Limbo_Init_Functions, random_sampling)
     std::cout << "RandomSampling" << std::endl;
 
 
-    using Model_t =  model::GP<kernel::MaternFiveHalves<limbo::defaults::kernel, limbo::defaults::kernel_maternfivehalves>>;
+    using Model_t =  model::GaussianProcess<kernel::MaternFiveHalves<limbo::defaults::kernel, limbo::defaults::kernel_maternfivehalves>>;
     using Acqui_t = acqui::UCB<RandSamplParams::acqui_ucb, Model_t>;
     using Init_t = init::RandomSampling<RandSamplParams::init_randomsampling>;
     using Opt_t = bayes_opt::BOptimizer<RandSamplParams, Model_t, Acqui_t, Init_t>;
@@ -186,7 +186,7 @@ TEST(Limbo_Init_Functions, random_sampling_grid)
     std::cout << "RandomSamplingGrid" << std::endl;
    
 
-    using Model_t =  model::GP<kernel::MaternFiveHalves<limbo::defaults::kernel, limbo::defaults::kernel_maternfivehalves>>;
+    using Model_t =  model::GaussianProcess<kernel::MaternFiveHalves<limbo::defaults::kernel, limbo::defaults::kernel_maternfivehalves>>;
     using Acqui_t = acqui::UCB<RandSamplGridParams::acqui_ucb, Model_t>;
     using Init_t = init::RandomSamplingGrid<RandSamplGridParams::init_randomsamplinggrid>;
     using Opt_t = bayes_opt::BOptimizer<RandSamplGridParams, Model_t, Acqui_t, Init_t>;
@@ -217,7 +217,7 @@ TEST(Limbo_Init_Functions, grid_sampling)
     std::cout << "GridSampling" << std::endl;
 
 
-    using Model_t =  model::GP<kernel::MaternFiveHalves<limbo::defaults::kernel, limbo::defaults::kernel_maternfivehalves>>;
+    using Model_t =  model::GaussianProcess<kernel::MaternFiveHalves<limbo::defaults::kernel, limbo::defaults::kernel_maternfivehalves>>;
     using Acqui_t = acqui::UCB<GridSamplParams::acqui_ucb, Model_t>;
     using Init_t = init::GridSampling<GridSamplParams::init_gridsampling>;
     using Opt_t = bayes_opt::BOptimizer<GridSamplParams, Model_t, Acqui_t, Init_t>;

--- a/tests/test_nlopt.cpp
+++ b/tests/test_nlopt.cpp
@@ -157,7 +157,7 @@ TEST(Limbo_NLOpt, nlopt_no_grad_constraint)
 // 	    struct acqui_ucb : defaults::acqui_ucb {};
 //     };
 //
-//     using Model = model::GP<kernel::SquaredExpARD<MyParams::kernel_opt, MyParams::kernel_squared_exp_ard>>;
+//     using Model = model::GaussianProcess<kernel::SquaredExpARD<MyParams::kernel_opt, MyParams::kernel_squared_exp_ard>>;
 //     using Acqui = acqui::UCB<MyParams::acqui_ucb, Model>;
 //
 // 	std::filesystem::path root = R"(C:\Users\NicholasAnthony\source\repos\wt_gui\external\WaveTracer\testing\optimizerTests\resources\DIA_highD\optimizations\hp_10_irpropplus_dual_1eneg3_unbound)";

--- a/tests/test_serialize.cpp
+++ b/tests/test_serialize.cpp
@@ -196,8 +196,8 @@ TEST(Limbo_Serialize, text_archive)
     test_gp<limbo::model::GPOpt<Params>, limbo::model::GPOpt<LoadParams>, limbo::serialize::TextArchive>(rootDir + "/gp_opt_text");
     test_gp<limbo::model::GPBasic<Params>, limbo::model::GPBasic<LoadParams>, limbo::serialize::TextArchive>(rootDir + "/gp_basic_text", false);
 
-    using GPMean = limbo::model::GP<limbo::kernel::MaternFiveHalves<Params::kernel, Params::kernel_maternfivehalves>, limbo::mean::Constant<Params::mean_constant>, limbo::model::gp::MeanLFOpt<limbo::opt::Irpropplus<Params::opt_irpropplus>>>;
-    using GPMeanLoad = limbo::model::GP<limbo::kernel::MaternFiveHalves<LoadParams::kernel, LoadParams::kernel_maternfivehalves>, limbo::mean::Constant<LoadParams::mean_constant>, limbo::model::gp::MeanLFOpt<limbo::opt::Irpropplus<LoadParams::opt_irpropplus>>>;
+    using GPMean = limbo::model::GaussianProcess<limbo::kernel::MaternFiveHalves<Params::kernel, Params::kernel_maternfivehalves>, limbo::mean::Constant<Params::mean_constant>, limbo::model::gp::MeanLFOpt<limbo::opt::Irpropplus<Params::opt_irpropplus>>>;
+    using GPMeanLoad = limbo::model::GaussianProcess<limbo::kernel::MaternFiveHalves<LoadParams::kernel, LoadParams::kernel_maternfivehalves>, limbo::mean::Constant<LoadParams::mean_constant>, limbo::model::gp::MeanLFOpt<limbo::opt::Irpropplus<LoadParams::opt_irpropplus>>>;
     test_gp<GPMean, GPMeanLoad, limbo::serialize::TextArchive>(rootDir + "/gp_mean_text");
 }
 
@@ -206,8 +206,8 @@ TEST(Limbo_Serialize, bin_archive)
     test_gp<limbo::model::GPOpt<Params>, limbo::model::GPOpt<LoadParams>, limbo::serialize::BinaryArchive>(rootDir + "/gp_opt_bin");
     test_gp<limbo::model::GPBasic<Params>, limbo::model::GPBasic<LoadParams>, limbo::serialize::BinaryArchive>(rootDir + "/gp_basic_bin", false);
 
-    using GPMean = limbo::model::GP<limbo::kernel::MaternFiveHalves<Params::kernel, Params::kernel_maternfivehalves>, limbo::mean::Constant<Params::mean_constant>, limbo::model::gp::MeanLFOpt<limbo::opt::Irpropplus<Params::opt_irpropplus>>>;
-    using GPMeanLoad = limbo::model::GP<limbo::kernel::MaternFiveHalves<LoadParams::kernel, LoadParams::kernel_maternfivehalves>, limbo::mean::Constant<LoadParams::mean_constant>, limbo::model::gp::MeanLFOpt<limbo::opt::Irpropplus<LoadParams::opt_irpropplus>>>;
+    using GPMean = limbo::model::GaussianProcess<limbo::kernel::MaternFiveHalves<Params::kernel, Params::kernel_maternfivehalves>, limbo::mean::Constant<Params::mean_constant>, limbo::model::gp::MeanLFOpt<limbo::opt::Irpropplus<Params::opt_irpropplus>>>;
+    using GPMeanLoad = limbo::model::GaussianProcess<limbo::kernel::MaternFiveHalves<LoadParams::kernel, LoadParams::kernel_maternfivehalves>, limbo::mean::Constant<LoadParams::mean_constant>, limbo::model::gp::MeanLFOpt<limbo::opt::Irpropplus<LoadParams::opt_irpropplus>>>;
     test_gp<GPMean, GPMeanLoad, limbo::serialize::BinaryArchive>(rootDir + "/gp_mean_bin");
 }
 

--- a/tutorials/gp.cpp
+++ b/tutorials/gp.cpp
@@ -85,15 +85,15 @@ int main(int argc, char** argv)
         observations.push_back(std::cos(s(0)));
     }
 
-    // the type of the GP
+    // the type of the GaussianProcess
     using Kernel_t = kernel::Exp<Params::kernel, Params::kernel_exp>;
     using Mean_t = mean::Data;
-    using GP_t = model::GP<Kernel_t, Mean_t>;
+    using GP_t = model::GaussianProcess<Kernel_t, Mean_t>;
 
     // 1-D inputs, 1-D outputs
     GP_t gp(1);
 
-    // compute the GP
+    // compute the GaussianProcess
     gp.initialize(samples, observations);
 
     // write the predicted data in a file (e.g. to be plotted)
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
     // in that case, we need a kernel with hyper-parameters that are designed to be optimized
     using Kernel2_t = kernel::SquaredExpARD<Params::kernel, Params::kernel_squared_exp_ard>;
     using Mean_t = mean::Data;
-    using GP2_t = model::GP<Kernel2_t, Mean_t, model::gp::KernelLFOpt<opt::Rprop<Params::opt_rprop>>>;
+    using GP2_t = model::GaussianProcess<Kernel2_t, Mean_t, model::gp::KernelLFOpt<opt::Rprop<Params::opt_rprop>>>;
 
     GP2_t gp_ard(1);
     // do not forget to call the optimization!
@@ -131,7 +131,7 @@ int main(int argc, char** argv)
     for (size_t i = 0; i < samples.size(); ++i)
         ofs_data << samples[i].transpose() << " " << observations[i] << std::endl;
 
-    // Sometimes is useful to save an optimized GP
+    // Sometimes is useful to save an optimized GaussianProcess
     gp_ard.save(serialize::TextArchive("myGP"));
 
     // Later we can load -- we need to make sure that the type is identical to the one saved

--- a/util/export_model_utility.cpp
+++ b/util/export_model_utility.cpp
@@ -37,8 +37,8 @@ namespace {
 int main()
 {
     using Kernel = kernel::SquaredExpARD<Params::kernel, Params::kernel_squared_exp_ard>;
-    using Model = model::GP<Kernel, mean::Data, model::gp::KernelLFOpt<opt::Irpropplus<Params::opt_irpropplus>>>;
-    // using Model = model::GP<Kernel, mean::Data, model::gp::KernelLFOpt<opt::Rprop<Params::opt_rprop>>>;
+    using Model = model::GaussianProcess<Kernel, mean::Data, model::gp::KernelLFOpt<opt::Irpropplus<Params::opt_irpropplus>>>;
+    // using Model = model::GaussianProcess<Kernel, mean::Data, model::gp::KernelLFOpt<opt::Rprop<Params::opt_rprop>>>;
 
     std::filesystem::path rootDir(R"(C:\Users\NicholasAnthony\source\repos\wt_gui\external\WaveTracer\testing\optimizerTests\resources\DIA_highD\optimizations\hp_10_irpropplus_ser_1eneg3)");
     Model m = Model::load(serialize::TextArchive((rootDir / "modelArchive_init").string()));

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,10 @@
   "dependencies": [
     "nlopt",
     "boost-fusion",
-    "tbb",
+    {
+      "name": "tbb",
+      "default-features":  false
+    },
     "gtest",
     "eigen3",
     "spdlog",


### PR DESCRIPTION
Various fixes aimed primarily as improving the comprehensibility of the code. Fewer abbreviations, use variable names that match the names in paper

A race condition that caused the parallelrepeater test to fail ~50% of the time has been fixed.

A config for building with address sanitizer 