### PR TITLE
Significantly speed up hyperparameter tuning

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -84,7 +84,7 @@
       "name": "Clang-Release-Fast",
       "inherits": "Clang-Release",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/fp:fast /EHsc"
+        "CMAKE_CXX_FLAGS": "/clang:-march=haswell /fp:fast /EHsc"
       }
     }
   ]

--- a/benchmarks/limbo/bench.cpp
+++ b/benchmarks/limbo/bench.cpp
@@ -133,23 +133,25 @@ BO_DECLARE_DYN_PARAM(int, BobyqaParams_HP::opt_nloptnograd, iterations);
 template <concepts::BayesOptimizer Optimizer, TestFunction Function>
 void optimize(benchmark::State& state)
 {
-
     int iters_base = 250;
     DirectParams::opt_nloptnograd::set_iterations(static_cast<int>(iters_base * Function::dim_in() * 0.9));
     BobyqaParams::opt_nloptnograd::set_iterations(iters_base * Function::dim_in() - DirectParams::opt_nloptnograd::iterations());
 
     BobyqaParams_HP::opt_nloptnograd::set_iterations(10 * Function::dim_in() * Function::dim_in());
 
+    double bestObs = 0;
+    Eigen::VectorXd bestSample;
+    double accuracy = 100;
     for (auto _ : state) {
         srand(time(NULL));
         Optimizer opt(Function::dim_in());
         Benchmark<Function> target;
         opt.optimize(target);
-        auto [bestObs, bestSample] = opt.model().best_observation();
-        double accuracy = target.accuracy(bestObs);
-        std::cout << "Result: " << std::fixed << bestSample.transpose() << " -> " << bestObs << std::endl;
-        std::cout << "Smallest difference: " << accuracy << std::endl;
+        std::tie(bestObs, bestSample) = opt.model().best_observation();
+        accuracy = target.accuracy(bestObs);
     }
+    std::cout << "Result: " << std::fixed << bestSample.transpose() << " -> " << bestObs << std::endl;
+    std::cout << "Smallest difference: " << accuracy << std::endl;
 }
 
 

--- a/benchmarks/limbo/hyperparametertuning.cpp
+++ b/benchmarks/limbo/hyperparametertuning.cpp
@@ -97,7 +97,7 @@ struct Model<PARALLEL_RPT_4> : Model<PARALLEL_RPT_2>
 template<GP_Type ModelType>
 void BM_KernelHPTune(benchmark::State& state)
 {
-	constexpr int numSamples = 5000;
+	constexpr int numSamples = 1000;
 	constexpr int dim = TestFunc::dim_in();
 
 	if (samples.empty()) {
@@ -115,13 +115,13 @@ void BM_KernelHPTune(benchmark::State& state)
 	switch (state.range(0))
 	{
 	case 0:
-		grad = 0;
-		break;
-	case 1:
 		grad = 1e-6;
 		break;
-	case 2:
+	case 1:
 		grad = 1e-3;
+		break;
+	case 2:
+		grad = 1e-1;
 		break;
 	default:
 		throw std::runtime_error("E");
@@ -138,13 +138,16 @@ void BM_KernelHPTune(benchmark::State& state)
 		Params::opt_parallel::set_repeats(4);
 	}
 
+	double before = 0;
+	double after = 0;
 	for (auto _ : state) {
 		typename Model<ModelType>::GP gp(dim);
 		gp.initialize(samples, observations);
-		const double before = gp.compute_log_lik();
+		before = gp.compute_log_lik();
 		gp.optimize_hyperparams();
-		std::cout << std::format("LogLik Before {}, After {}\n", before, gp.compute_log_lik());
+		after = gp.compute_log_lik();
 	}
+	std::cout << std::format("LogLik Before {}, After {}\n", before, after);
 }
 
 BENCHMARK(BM_KernelHPTune<R_PROP>)->ArgNames({"MinGradient"})->Arg(0)->Arg(1)->Arg(2)->Unit(benchmark::kMillisecond)->MinTime(6);

--- a/src/limbo/kernel/kernel.hpp
+++ b/src/limbo/kernel/kernel.hpp
@@ -70,6 +70,7 @@ namespace limbo {
              - ``double noise`` (initial signal noise squared)
              - ``bool optimize_noise`` (whether we are optimizing for the noise or not)
         */
+        //TODO allow templating out the `noise` handling.
         template <typename kernel_opt, typename Kernel>
         struct BaseKernel {
         public:
@@ -78,18 +79,18 @@ namespace limbo {
                 _noise_p = std::log(std::sqrt(_noise));
             }
 
-            double compute(const Eigen::VectorXd& v1, const Eigen::VectorXd& v2, int i = -1, int j = -2) const
+            double compute(const Eigen::VectorXd& v1, const Eigen::VectorXd& v2, bool isDiagonalElement = false) const
             {
-                return static_cast<const Kernel*>(this)->kernel_(v1, v2) + ((i == j) ? _noise + 1e-8 : 0.0);
+                return static_cast<const Kernel*>(this)->kernel_(v1, v2) + (isDiagonalElement ? _noise + 1e-8 : 0.0);
             }
 
-            Eigen::VectorXd grad(const Eigen::VectorXd& x1, const Eigen::VectorXd& x2, int i = -1, int j = -2) const
+            Eigen::VectorXd grad(const Eigen::VectorXd& x1, const Eigen::VectorXd& x2, bool isDiagonalElement = false) const
             {
                 Eigen::VectorXd g = static_cast<const Kernel*>(this)->gradient_(x1, x2);
 
                 if (kernel_opt::optimize_noise()) {
                     g.conservativeResize(g.size() + 1);
-                    g(g.size() - 1) = ((i == j) ? 2.0 * _noise : 0.0);
+                    g(g.size() - 1) = (isDiagonalElement ? 2.0 * _noise : 0.0);
                 }
 
                 return g;

--- a/src/limbo/kernel/kernel.hpp
+++ b/src/limbo/kernel/kernel.hpp
@@ -74,7 +74,7 @@ namespace limbo {
         template <typename kernel_opt, typename Kernel>
         struct BaseKernel {
         public:
-            BaseKernel(size_t dim = 1) : _noise(kernel_opt::noise())
+            BaseKernel() : _noise(kernel_opt::noise())
             {
                 _noise_p = std::log(std::sqrt(_noise));
             }

--- a/src/limbo/kernel/squared_exp_ard.hpp
+++ b/src/limbo/kernel/squared_exp_ard.hpp
@@ -112,8 +112,8 @@ namespace limbo {
                 else {
                     Eigen::VectorXd grad(this->params_size_());
                     Eigen::VectorXd z = (x1 - x2).cwiseProduct(_ell_inv).array().square();
-                    double k = _sf2 * std::exp(-0.5 * z.sum());
-                    grad.head(_input_dim) = z * k;
+                    const double k = _sf2 * std::exp(-0.5 * z.sum());
+                    grad.head(_input_dim).noalias() = z * k;
 
                     grad(grad.size() - 1) = 2 * k;
                     return grad;

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -58,6 +58,10 @@
 // Quick hack for definition of 'I' in <complex.h>
 #undef I
 
+#ifdef LIMBO_USE_TBB
+#include <tbb/tbb.h>
+#endif
+
 #include <numeric>
 #include <limbo/kernel/matern_five_halves.hpp>
 #include <limbo/kernel/squared_exp_ard.hpp>
@@ -225,6 +229,53 @@ namespace limbo {
 
                 // only compute half of the matrix (symmetrical matrix)
                 Eigen::VectorXd grad = Eigen::VectorXd::Zero(_kernel_function.h_params_size());
+#ifdef LIMBO_USE_TBB
+                struct ParallelWorker
+                { // This worker works with TBB to iterate over the lower triangle of the kernel to accumulate the values of the gradient.
+                    ParallelWorker(GaussianProcess* gp, Eigen::MatrixXd const& w):
+						gp_(gp),
+						w_(w),
+						thisGrad_(Eigen::VectorXd::Zero(gp_->_kernel_function.h_params_size()))
+                    {}
+
+	                void operator()(tbb::blocked_range<size_t> const& r)
+	                {
+		                for (size_t j=r.begin(); j!=r.end(); ++j)
+		                {
+                            for (size_t i = j; i < w_.rows(); ++i) {
+                                const bool isDiagonalElement = i == j;
+                                Eigen::VectorXd g = gp_->_kernel_function.grad(gp_->_samples[i], gp_->_samples[j], isDiagonalElement);
+                                if (isDiagonalElement) [[unlikely]]
+                                    thisGrad_ += w_(i, j) * g * 0.5;
+                                else
+                                    thisGrad_ += w_(i, j) * g;
+                            }
+		                }
+	                }
+
+                    //TBB uses this to split workers.
+                    ParallelWorker(ParallelWorker const& other, tbb::split):
+						gp_(other.gp_),
+						w_(other.w_),
+                        thisGrad_(Eigen::VectorXd::Zero(gp_->_kernel_function.h_params_size()))
+					{}
+
+                    void join(ParallelWorker const& other)
+                    { // TBB uses this to combine workers.
+                        thisGrad_ += other.thisGrad_;
+                    }
+
+                    Eigen::VectorXd getGradient() const { return thisGrad_; }
+                private:
+                    GaussianProcess* gp_;
+                    Eigen::MatrixXd const& w_;
+                    Eigen::VectorXd thisGrad_;
+                };
+
+                ParallelWorker worker(this, w);
+                tbb::parallel_reduce(tbb::blocked_range<size_t>(0, n), worker);
+                grad = worker.getGradient();
+#else
                 for (size_t j=0; j<n; ++j) {
 					for (size_t i=j; i<n; ++i) {
                         const bool isDiagonalElement = i == j;
@@ -235,6 +286,7 @@ namespace limbo {
                             grad += w(i, j) * g;
                     }
                 }
+#endif
                 return grad;
             }
 
@@ -429,7 +481,19 @@ namespace limbo {
                 size_t n = _samples.size();
                 _kernel.resize(n, n);
 
-                // Compute lower triangle
+                // Compute lower triangle of kernel
+#ifdef LIMBO_USE_TBB
+                tbb::parallel_for(tbb::blocked_range<size_t>(0, n), [this, n](tbb::blocked_range<size_t> const& r)
+                {
+	                for (size_t j=r.begin(); j!=r.end(); ++j)
+	                {
+                        for (size_t i = j; i < n; i++)
+                        {
+                            _kernel(i, j) = _kernel_function.compute(_samples[i], _samples[j], i == j);
+                        }
+	                }
+                });
+#else
                 for (size_t j=0; j<n; ++j)
                 {
                     for (size_t i=j; i<n; i++)
@@ -437,6 +501,7 @@ namespace limbo {
                         _kernel(i, j) = _kernel_function.compute(_samples[i], _samples[j], i == j);
                     }
                 }
+#endif
 
                 // O(n^3)
                 _matrixL = Eigen::LLT<Eigen::MatrixXd, Eigen::Lower>(_kernel).matrixL(); // _matrixL * _matrixL.transpose = _kernel

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -526,13 +526,12 @@ namespace limbo {
                     _kernel(n - 1, i) = _kernel_function.compute(_samples[i], _samples[n - 1], i == n - 1);
                 }
 
-                double L_j;
                 for (size_t j = 0; j < n - 1; ++j) {
-                    L_j = _kernel(n - 1, j) - (_matrixL.block(j, 0, 1, j) * _matrixL.block(n - 1, 0, 1, j).transpose())(0, 0);
+                    const double L_j = _kernel(n - 1, j) - (_matrixL.block(j, 0, 1, j) * _matrixL.block(n - 1, 0, 1, j).transpose())(0, 0);
                     _matrixL(n - 1, j) = (L_j) / _matrixL(j, j);
                 }
 
-                L_j = _kernel(n - 1, n - 1) - (_matrixL.block(n - 1, 0, 1, n - 1) * _matrixL.block(n - 1, 0, 1, n - 1).transpose())(0, 0);
+                const double L_j = _kernel(n - 1, n - 1) - (_matrixL.block(n - 1, 0, 1, n - 1) * _matrixL.block(n - 1, 0, 1, n - 1).transpose())(0, 0);
                 _matrixL(n - 1, n - 1) = sqrt(L_j);
 
                 this->_compute_alpha();
@@ -545,7 +544,7 @@ namespace limbo {
             {
                 // alpha = K^{-1} * this->observation_deviation_;
                 Eigen::TriangularView<Eigen::MatrixXd, Eigen::Lower> triang = _matrixL.triangularView<Eigen::Lower>();
-                _alpha = triang.solve(observation_deviation_);
+                _alpha.noalias() = triang.solve(observation_deviation_);
                 triang.adjoint().solveInPlace(_alpha);
             }
 
@@ -556,7 +555,7 @@ namespace limbo {
 
             double _sigma_sq(Eigen::VectorXd const& v, Eigen::VectorXd const& k) const
             {
-                Eigen::VectorXd z = _matrixL.triangularView<Eigen::Lower>().solve(k);
+                Eigen::VectorXd z = _matrixL.triangularView<Eigen::Lower>().solve(k); // This is equivalent to (k^T * K^-1 * k) -> (k^T * L^-1T * L^-1 * k) -> ((L^-1 * k)^T * (L^-1 * k))
                 double res = _kernel_function.compute(v, v) - z.dot(z);
 
                 return (res <= std::numeric_limits<double>::epsilon()) ? 0 : res;
@@ -588,10 +587,10 @@ namespace limbo {
             {
                 const size_t n = observation_deviation_.rows();
                 // K^{-1} using Cholesky decomposition
-                _inv_kernel = Eigen::MatrixXd::Identity(n, n);
+                _inv_kernel.setIdentity(n, n);
 
-                _matrixL.triangularView<Eigen::Lower>().solveInPlace(_inv_kernel);
-                _matrixL.triangularView<Eigen::Lower>().transpose().solveInPlace(_inv_kernel);
+                _matrixL.triangularView<Eigen::Lower>().solveInPlace(_inv_kernel); // After this step `_inv_kernel` is the inverse of `_matrixL`
+            	_matrixL.triangularView<Eigen::Lower>().transpose().solveInPlace(_inv_kernel);
 
                 _inv_kernel_updated = true;
             }

--- a/src/limbo/model/gp/kernel_lf_opt.hpp
+++ b/src/limbo/model/gp/kernel_lf_opt.hpp
@@ -47,6 +47,7 @@
 #define LIMBO_MODEL_GP_KERNEL_LF_OPT_HPP
 
 #include <limbo/opt/irprop_plus.hpp>
+#include <tbb/enumerable_thread_specific.h>
 
 namespace limbo {
     namespace model {
@@ -77,11 +78,11 @@ namespace limbo {
 
                 template <typename GP>
                 struct KernelLFOptimization {
-                    KernelLFOptimization(const GP& gp) : gp_(gp) {}
+                    KernelLFOptimization(const GP& gp) : gp_ets_(gp) {}
 
                     opt::eval_t operator()(const Eigen::VectorXd& params, bool compute_grad) const
                     {
-                        GP gp(gp_);
+                        GP& gp = gp_ets_.local();
                         gp.set_kernel_hyperparams(params);
 
                         double lik = gp.compute_log_lik();
@@ -95,7 +96,7 @@ namespace limbo {
                     }
 
                 private:
-                    GP const& gp_;
+                    mutable tbb::enumerable_thread_specific<GP> gp_ets_;
                 };
             };
         } // namespace gp

--- a/src/limbo/opt/irprop_plus.hpp
+++ b/src/limbo/opt/irprop_plus.hpp
@@ -14,6 +14,8 @@ namespace limbo {
             /// @ingroup opt_defaults
             /// number of max iterations
             BO_PARAM(int, max_iterations, 300);
+
+            // The initial step size for the optimizer
             BO_PARAM(double, init_delta, 0.1);
             BO_PARAM(double, max_delta, 50);
             BO_PARAM(double, min_delta, 1e-6);

--- a/src/limbo/tools/parallel.hpp
+++ b/src/limbo/tools/parallel.hpp
@@ -53,11 +53,9 @@
 // Quick hack for definition of 'I' in <complex.h>
 #undef I
 #include <tbb/blocked_range.h>
-#include <tbb/concurrent_vector.h>
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_for_each.h>
 #include <tbb/parallel_reduce.h>
-#include <tbb/parallel_sort.h>
 #endif
 
 ///@defgroup par_tools

--- a/src/limbo/tools/parallel.hpp
+++ b/src/limbo/tools/parallel.hpp
@@ -62,122 +62,69 @@
 
 ///@defgroup par_tools
 
-namespace limbo {
-    namespace tools {
-        namespace par {
+namespace limbo::tools::par {
+    ///@ingroup par_tools
+    /// parallel for
+    template <typename F>
+    void loop(size_t begin, size_t end, const F& f)
+    {
 #ifdef LIMBO_USE_TBB
-            template <typename X>
-            using vector = tbb::concurrent_vector<X>; // Template alias (for GCC 4.7 and later)
-
-        	/// @ingroup par_tools
-            /// convert a std::vector to something else (e.g. a std::list)
-            template <typename V>
-            std::vector<typename V::value_type> convert_vector(const V& v)
-            {
-                std::vector<typename V::value_type> v2(v.size());
-                std::copy(v.begin(), v.end(), v2.begin());
-                return v2;
-            }
+        tbb::parallel_for(size_t(begin), end, size_t(1), [&](size_t i) {
+            f(i);
+        });
 #else
-
-            template <typename V>
-            V convert_vector(const V& v)
-            {
-                return v;
-            }
-
+        for (size_t i = begin; i < end; ++i)
+            f(i);
 #endif
-            ///@ingroup par_tools
-            /// parallel for
-            template <typename F>
-            void loop(size_t begin, size_t end, const F& f)
-            {
-#ifdef LIMBO_USE_TBB
-                tbb::parallel_for(size_t(begin), end, size_t(1), [&](size_t i) {
-                    
-                f(i);
-                    
-                });
-#else
-                for (size_t i = begin; i < end; ++i)
-                    f(i);
-#endif
-            }
-
-            /// @ingroup par_tools
-            /// parallel for_each
-            template <typename Iterator, typename F>
-            void for_each(Iterator begin, Iterator end, const F& f)
-            {
-#ifdef LIMBO_USE_TBB
-                tbb::parallel_for_each(begin, end, f);
-#else
-                for (Iterator i = begin; i != end; ++i)
-                    f(*i);
-#endif
-            }
-
-            /// @ingroup par_tools
-            /// parallel max
-            template <typename T, typename F, typename C>
-            T max(const T& init, int num_steps, const F& f, const C& comp)
-            {
-#ifdef LIMBO_USE_TBB
-                auto body = [&](const tbb::blocked_range<size_t>& r, T current_max) -> T {
-                    
-		            for (size_t i = r.begin(); i != r.end(); ++i)
-		            {
-		                T v = f(i);
-		                if (comp(v, current_max))
-		                  current_max = v;
-		            }
-		            return current_max;
-	                    
-	            };
-	            auto joint = [&](const T& p1, const T& p2) -> T {
-		            if (comp(p1, p2))
-		                return p1;
-		            return p2;
-                };
-                return tbb::parallel_reduce(tbb::blocked_range<size_t>(0, num_steps), init, body, joint);
-#else
-                T current_max = init;
-                for (int i = 0; i < num_steps; ++i) {
-                    T v = f(i);
-                    if (comp(v, current_max))
-                        current_max = v;
-                }
-                return current_max;
-#endif
-            }
-            /// @ingroup par_tools
-            /// parallel sort
-            template <typename T1, typename T2, typename T3>
-            void sort(T1 i1, T2 i2, T3 comp)
-            {
-#ifdef LIMBO_USE_TBB
-                tbb::parallel_sort(i1, i2, comp);
-#else
-                std::sort(i1, i2, comp);
-#endif
-            }
-
-            /// @ingroup par_tools
-            /// replicate a function nb times
-            template <typename F>
-            void replicate(size_t nb, const F& f)
-            {
-#ifdef LIMBO_USE_TBB
-                tbb::parallel_for(size_t(0), nb, size_t(1), [&](size_t i) {
-					f();
-                });
-#else
-                for (size_t i = 0; i < nb; ++i)
-                    f();
-#endif
-            }
-        }
     }
+
+    /// @ingroup par_tools
+    /// parallel for_each
+    template <typename Iterator, typename F>
+    void for_each(Iterator begin, Iterator end, const F& f)
+    {
+#ifdef LIMBO_USE_TBB
+        tbb::parallel_for_each(begin, end, f);
+#else
+        for (Iterator i = begin; i != end; ++i)
+            f(*i);
+#endif
+    }
+
+    /// @ingroup par_tools
+    /// parallel max
+    template <typename T, typename F, typename C>
+    T max(const T& init, int num_steps, const F& f, const C& comp)
+    {
+#ifdef LIMBO_USE_TBB
+        auto body = [&](const tbb::blocked_range<size_t>& r, T current_max) -> T {
+            
+            for (size_t i = r.begin(); i != r.end(); ++i)
+            {
+                T v = f(i);
+                if (comp(v, current_max))
+                  current_max = v;
+            }
+            return current_max;
+                
+        };
+        auto joint = [&](const T& p1, const T& p2) -> T {
+            if (comp(p1, p2))
+                return p1;
+            return p2;
+        };
+        return tbb::parallel_reduce(tbb::blocked_range<size_t>(0, num_steps), init, body, joint);
+#else
+        T current_max = init;
+        for (int i = 0; i < num_steps; ++i) {
+            T v = f(i);
+            if (comp(v, current_max))
+                current_max = v;
+        }
+        return current_max;
+#endif
+    }
+
 }
 
 #endif

--- a/tests/bo_functions.cpp
+++ b/tests/bo_functions.cpp
@@ -326,7 +326,7 @@ int main(int argc, char** argv)
     using Opt_t = bayes_opt::BOptimizer<Params>;
 
     if (!is_in_argv(argc, argv, "--only") || is_in_argv(argc, argv, "sphere"))
-        tools::par::replicate(nb_replicates, [&]() {
+        tools::par::loop(0, nb_replicates, [&](size_t i) {
             
                 Opt_t opt(Sphere::dim_in());
                 opt.optimize(Sphere());
@@ -337,7 +337,7 @@ int main(int argc, char** argv)
         });
 
     if (!is_in_argv(argc, argv, "--only") || is_in_argv(argc, argv, "ellipsoid"))
-        tools::par::replicate(nb_replicates, [&]() {
+        tools::par::loop(0, nb_replicates, [&](size_t i) {
             
                 Opt_t opt(Ellipsoid::dim_in());
                 opt.optimize(Ellipsoid());
@@ -348,7 +348,7 @@ int main(int argc, char** argv)
         });
 
     if (!is_in_argv(argc, argv, "--only") || is_in_argv(argc, argv, "rastrigin"))
-        tools::par::replicate(nb_replicates, [&]() {
+        tools::par::loop(0, nb_replicates, [&](size_t i) {
             
                 Opt_t opt(Rastrigin::dim_in());
                 opt.optimize(Rastrigin());
@@ -359,7 +359,7 @@ int main(int argc, char** argv)
         });
 
     if (!is_in_argv(argc, argv, "--only") || is_in_argv(argc, argv, "hartman3"))
-        tools::par::replicate(nb_replicates, [&]() {
+        tools::par::loop(0, nb_replicates, [&](size_t i) {
             
                 Opt_t opt(Hartman3::dim_in());
                 opt.optimize(Hartman3());
@@ -371,7 +371,7 @@ int main(int argc, char** argv)
         });
 
     if (!is_in_argv(argc, argv, "--only") || is_in_argv(argc, argv, "hartman6"))
-        tools::par::replicate(nb_replicates, [&]() {
+        tools::par::loop(0, nb_replicates, [&](size_t i) {
             
                 Opt_t opt(Hartman6::dim_in());
                 opt.optimize(Hartman6());
@@ -384,7 +384,7 @@ int main(int argc, char** argv)
         });
 
     if (!is_in_argv(argc, argv, "--only") || is_in_argv(argc, argv, "golden_price"))
-        tools::par::replicate(nb_replicates, [&]() {
+        tools::par::loop(0, nb_replicates, [&](size_t i) {
             
                 Opt_t opt(GoldenPrice::dim_in());
                 opt.optimize(GoldenPrice());


### PR DESCRIPTION
This PR includes changes that dramatically speed up hyperparameter tuning.

 - Upper triangle of the kernel matrix is not popuplated since it isn't used
 - Matrices are iterated over in column-major order. That is how they are stored.
 - Some computatations are multi-threaded thanks to TBB
 - The kernel likelihood optimizer no longer creates a new copy of the gaussian process on every iteration of optimization.
![image](https://github.com/user-attachments/assets/b4e241d0-9a6a-4d0a-bd17-ede074a1a26d)
