### PR TITLE
Evaluate output functions on every iteration

### DIFF
--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -214,7 +214,7 @@ namespace limbo {
 
         protected:
             typename boost::mpl::if_<boost::fusion::traits::is_sequence<StoppingCriteria>, StoppingCriteria, boost::fusion::vector<StoppingCriteria>>::type stopping_criteria_;
-            stats_t  stat_;
+            stats_t  outputFuncs_;
             std::filesystem::path outputDir_;
         private:
             model_type _model;

--- a/src/limbo/bayes_opt/boptimizer_impl.hpp
+++ b/src/limbo/bayes_opt/boptimizer_impl.hpp
@@ -94,16 +94,6 @@ namespace limbo::bayes_opt
 				break;
 			}
 
-			if (Params::bayes_opt_boptimizer::stats_enabled()) {
-				//update stats
-				boost::fusion::for_each(
-					stat_, 
-					[this](concepts::StatsFunc auto& func)
-					{
-						func.template operator()<decltype(*this)>(*this);
-					});
-			}
-
 			if (Params::bayes_opt_boptimizer::hp_period() > 0)
 			{
 				if ((iterations_since_hp_optimize_ + 1) % static_cast<int>(Params::bayes_opt_boptimizer::hp_period() + _total_iterations * Params::bayes_opt_boptimizer::hp_period_scaler()) == 0)
@@ -154,6 +144,17 @@ namespace limbo::bayes_opt
 			}
 			_model.add_sample(sample, observation);
 		}
+
+		if (Params::bayes_opt_boptimizer::stats_enabled()) {
+			// Call all Output functions
+			boost::fusion::for_each(
+				outputFuncs_,
+				[this](concepts::OutputFunc auto& func)
+				{
+					func.template operator()<decltype(*this)>(*this);
+				});
+		}
+
 		return status;
 	}
 
@@ -182,6 +183,6 @@ namespace limbo::bayes_opt
 		assert(exists(dir));
 		assert(std::filesystem::is_directory(dir));
 		outputDir_ = dir;
-		boost::fusion::for_each(stat_, [&dir](auto& stat) {stat.setOutputDirectory(dir); });
+		boost::fusion::for_each(outputFuncs_, [&dir](auto& stat) {stat.setOutputDirectory(dir); });
 	}
 }

--- a/src/limbo/concepts.hpp
+++ b/src/limbo/concepts.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <limbo/public.hpp>
 #include <concepts>
+#include <filesystem>
 #include <optional>
 #include <Eigen/Dense>
 
@@ -104,11 +105,12 @@ namespace limbo::concepts
 		{ a.optimize(EvalFuncArchetype{}, Eigen::VectorXd{}, std::optional<std::vector<std::pair<double, double>>>{}) } -> std::convertible_to<Eigen::VectorXd>;
 	};
 
-	//Receives data about the model and saves/logs it somewhere
+	//Receives data about the model and saves/logs it somewhere. This is called each time after the state function is evaluated and added to the model.
 	template <typename T>
-	concept StatsFunc = requires (T a)
+	concept OutputFunc = requires (T a)
 	{
 		{ a.operator()(BayesOptimizerArchetype{}) } -> std::convertible_to<void>;
+		{ a.setOutputDirectory(std::filesystem::path("")) } -> std::convertible_to<void>;
 	} &&
 		std::is_default_constructible_v<T>;
 

--- a/src/limbo/stat/runtime_stats_function.hpp
+++ b/src/limbo/stat/runtime_stats_function.hpp
@@ -5,7 +5,7 @@
 namespace limbo::stat
 {
 	//This class acts as an adapter between limbo's all-static registration of stats functions. Allows registering a dynamic function to be called.
-	struct RuntimeStatsFunction : StatBase
+	struct RuntimeOutputFunction : StatBase
 	{
 		using FuncT = std::function<void(double, Eigen::VectorXd, const std::vector<double>&, const std::vector<Eigen::VectorXd>&)>;
 
@@ -27,5 +27,5 @@ namespace limbo::stat
 		std::vector<FuncT> outFuncs_;
 	};
 
-	static_assert(limbo::concepts::StatsFunc<RuntimeStatsFunction>);
+	static_assert(limbo::concepts::OutputFunc<RuntimeOutputFunction>);
 }

--- a/src/limbo/tools/macros.hpp
+++ b/src/limbo/tools/macros.hpp
@@ -47,7 +47,7 @@
 #define LIMBO_TOOLS_MACROS_HPP
 
 #define BO_PARAM(Type, Name, Value) \
-    static constexpr auto Name = []()constexpr -> Type { return Value; };
+    static constexpr auto Name = []() consteval -> Type { return Value; };
 
 #define BO_DYN_PARAM(Type, Name)           \
     static Type _##Name;                   \


### PR DESCRIPTION
The bayesian optimizer previously maintained a list of functors referred to as `StatFuncs`, these were evaluated after each evaluation of the state function and are used to output data about the optimization on each iteration. However, they confusingly were not called upon during initialization calls to the state function.

This PR renames `StatFunc` to `OutputFunc` and changes the implementation so that they are called after every evaluation of the state function, including during initialization.

The concept that constrains these functions is improved upon.